### PR TITLE
파싱에서 script 문장형태 검사를 위한 내용을 추가 했습니다. 추가한 코드라인은  5줄 이내 입니다.

### DIFF
--- a/TeamBest_SSD_Shell/SSD_Shell.cpp
+++ b/TeamBest_SSD_Shell/SSD_Shell.cpp
@@ -276,7 +276,10 @@ bool SSDShell::UpdateCommand(std::string cmd) {
 	std::smatch match;
 	std::regex pattern(R"(^(\d+)_([a-z]+))");
 
-	if (std::regex_match(cmd, match, pattern)) { parsingresult.command = SCRIPT_EXECUTE;}
+	if (std::regex_match(cmd, match, pattern)) {
+		parsingresult.script_number = std::stoi(match[1].str());
+		parsingresult.command = SCRIPT_EXECUTE;
+	}
 	else if (cmd == "write") { parsingresult.command = WRITE; }
 	else if (cmd == "read") { parsingresult.command = READ; }
 	else if (cmd == "fullwrite") { parsingresult.command = FULL_WRITE; }

--- a/TeamBest_SSD_Shell/SSD_Shell.cpp
+++ b/TeamBest_SSD_Shell/SSD_Shell.cpp
@@ -183,7 +183,6 @@ bool SSDShell::ProcessParseInvalid(std::string command) {
 		try {
 			parsingresult.address = std::stoi(tokens[1]);
 
-
 			if (!IsValidAddressRange()) {
 				UpdateInvalidType_and_PrintErrorMessage(INVAILD_ADDRESS);
 				return true;
@@ -269,17 +268,23 @@ void SSDShell::UpdateInvalidType_and_PrintErrorMessage(int error_type) {
 
 bool SSDShell::UpdateCommand(std::string cmd) {
 
+	// Change Upper characters to Lower characters
 	std::transform(cmd.begin(), cmd.end(), cmd.begin(),
 		[](unsigned char c) { return std::tolower(c); });
 
-	if (cmd == "write") { parsingresult.command = WRITE; }
+	// 정규표현식: 맨 앞에 "숫자 + 언더바" 형식인지 확인  (Check Number+Underbar)
+	std::smatch match;
+	std::regex pattern(R"(^(\d+)_([a-z]+))");
+
+	if (std::regex_match(cmd, match, pattern)) { parsingresult.command = SCRIPT_EXECUTE;}
+	else if (cmd == "write") { parsingresult.command = WRITE; }
 	else if (cmd == "read") { parsingresult.command = READ; }
 	else if (cmd == "fullwrite") { parsingresult.command = FULL_WRITE; }
 	else if (cmd == "fullread") { parsingresult.command = FULL_READ; }
 	else if (cmd == "exit") { parsingresult.command = EXIT; }
 	else if (cmd == "help") { parsingresult.command = HELP; }
 	else { return false; }
-
+	
 	return true;
 }
 

--- a/TeamBest_SSD_Shell/SSD_Shell.cpp
+++ b/TeamBest_SSD_Shell/SSD_Shell.cpp
@@ -277,7 +277,7 @@ bool SSDShell::UpdateCommand(std::string cmd) {
 	std::regex pattern(R"(^(\d+)_([a-z]+))");
 
 	if (std::regex_match(cmd, match, pattern)) {
-		parsingresult.script_number = std::stoi(match[1].str());
+		parsingresult.script_name = cmd;
 		parsingresult.command = SCRIPT_EXECUTE;
 	}
 	else if (cmd == "write") { parsingresult.command = WRITE; }

--- a/TeamBest_SSD_Shell/SSD_Shell.h
+++ b/TeamBest_SSD_Shell/SSD_Shell.h
@@ -74,6 +74,7 @@ class SSDShell {
 public:
 	struct ParsingResult {
 		int command;
+		int script_number;
 		int address;
 		std::string data;
 		InvalidType invalidtype;

--- a/TeamBest_SSD_Shell/SSD_Shell.h
+++ b/TeamBest_SSD_Shell/SSD_Shell.h
@@ -18,7 +18,8 @@ enum Command {
 	EXIT = 3,
 	HELP = 4,
 	FULL_WRITE = 5,
-	FULL_READ = 6
+	FULL_READ = 6,
+	SCRIPT_EXECUTE =7
 };
 
 enum InvalidType {

--- a/TeamBest_SSD_Shell/SSD_Shell.h
+++ b/TeamBest_SSD_Shell/SSD_Shell.h
@@ -74,9 +74,9 @@ class SSDShell {
 public:
 	struct ParsingResult {
 		int command;
-		int script_number;
 		int address;
 		std::string data;
+		std::string script_name;
 		InvalidType invalidtype;
 	} parsingresult;
 

--- a/TeamBest_SSD_Shell/test_ssd_shell1.cpp
+++ b/TeamBest_SSD_Shell/test_ssd_shell1.cpp
@@ -1,4 +1,4 @@
-#include <iostream>
+﻿#include <iostream>
 #include "gmock/gmock.h"
 #include "SSD_Shell.h"
 
@@ -16,7 +16,7 @@ TEST(ShellTS, CheckRunMethod) {
 
 TEST(ShellTS, ExitCommandTest) {
 	SSDShell* ssdShell = new SSDShell();
-	SSDShell::ParsingResult parsingresult{Command::EXIT, 0, " ", InvalidType::NO_ERROR};
+	SSDShell::ParsingResult parsingresult{Command::EXIT, 0, " ", " ", InvalidType::NO_ERROR};
 
 	EXPECT_EQ(true,  ssdShell->ExcuteCommand(parsingresult));
 }


### PR DESCRIPTION
// 정규표현식: 맨 앞에 "숫자 + 언더바" 형식인지 확인  (Check Number+Underbar)
 std::smatch match;
 std::regex pattern(R"(^(\d+)_([a-z]+))");

아래 enum 형의  SCRIPT_EXECUTE =7 추가 (스크립트 숫자 언더바를 검사하기 위함)