### PR TITLE
[bugfix] shell 에서 1_ 로 시작하는게 안먹히는 문제 수정

### DIFF
--- a/TeamBest_SSD_Shell/SSD_Shell.cpp
+++ b/TeamBest_SSD_Shell/SSD_Shell.cpp
@@ -309,7 +309,7 @@ bool SSDShell::UpdateCommand(std::string cmd) {
 
 	// 정규표현식: 맨 앞에 "숫자 + 언더바" 형식인지 확인  (Check Number+Underbar)
 	std::smatch match;
-	std::regex pattern(R"(^(\d+)_([a-z]+))");
+	std::regex pattern(R"(^(\d+)_([a-z]*))");
 
 	if (std::regex_match(cmd, match, pattern)) {
 		parsingresult.script_name = cmd;


### PR DESCRIPTION
변경점 : 정규식에서 1_뒤에 알파벳이 0개 이상 올 수 있는 조건으로 수정함
검증

[ v] Build

[ v] Regression Test Pass

[ v] 해당 기능 TC