### PR TITLE
[Refactor] Command Parser - Command 별 Handle 함수 분리

### DIFF
--- a/TeamBest_SSD_Shell/ShellCommandParser.cpp
+++ b/TeamBest_SSD_Shell/ShellCommandParser.cpp
@@ -38,6 +38,8 @@ bool ShellCommandParser::ProcessParseInvalid(const std::string& command) {
 }
 
 bool ShellCommandParser::Fail(InvalidType type) {
+
+	LOG_MESSAGE("ShellCommandParser::Fail()", "InvalidType : " + std::to_string(type));
     UpdateInvalidType_and_PrintErrorMessage(type);
     return true;
 }

--- a/TeamBest_SSD_Shell/ShellCommandParser.h
+++ b/TeamBest_SSD_Shell/ShellCommandParser.h
@@ -1,5 +1,4 @@
-﻿// ShellCommandParser.h
-#pragma once
+﻿#pragma once
 
 #include <string>
 #include <vector>
@@ -42,8 +41,8 @@ public:
     int GetStartLba() const { return startlba; }
     int GetEndLba() const { return endlba_or_size; }
     int GetSize() const { return endlba_or_size; }
-    std::string GetData() const { return data; }
-    std::string GetScriptName() const { return script_name; }
+    const std::string& GetData() const { return data; }
+    const std::string& GetScriptName() const { return script_name; }
     InvalidType GetInvalidType() const { return invalidtype; }
 
     void SetCommand(int cmd) { command = cmd; }
@@ -54,7 +53,7 @@ public:
     void SetInvalidType(InvalidType type) { invalidtype = type; }
 
     bool IsInvalidCommand() const { return invalidtype != NO_ERROR; }
-    bool IsInvalidAddressRange(int lba) { return (lba < 0 || lba >= 100); }
+    bool IsInvalidAddressRange(int lba) const { return (lba < 0 || lba >= 100); }
 
 private:
     int command;
@@ -65,21 +64,19 @@ private:
     InvalidType invalidtype;
 };
 
-extern ParsingResult parsingresult;
-
 class ShellCommandParser {
 public:
     ShellCommandParser() = default;
     ~ShellCommandParser() = default;
 
-    bool ProcessParseInvalid(std::string command);
-    ParsingResult GetParsingResult() const { return parsingResult; }
+    bool ProcessParseInvalid(const std::string& command);
+    const ParsingResult& GetParsingResult() const { return parsingResult; }
 
 private:
-    std::vector<std::string> ParsingInputCommand(std::string command);
-    void UpdateInvalidType_and_PrintErrorMessage(int error_type);
-    bool UpdateCommand(std::string cmd);
-    bool IsValidAddressRange(int lba);
+    std::vector<std::string> ParsingInputCommand(const std::string& command);
+    void UpdateInvalidType_and_PrintErrorMessage(InvalidType type);
+    bool UpdateCommand(const std::string& cmd);
+    bool IsValidAddressRange(int lba) const;
     bool Fail(InvalidType type);
 
     bool HandleWriteCommand(const std::vector<std::string>& tokens);

--- a/TeamBest_SSD_Shell/ShellCommandParser.h
+++ b/TeamBest_SSD_Shell/ShellCommandParser.h
@@ -1,4 +1,5 @@
-﻿#pragma once
+﻿// ShellCommandParser.h
+#pragma once
 
 #include <string>
 #include <vector>
@@ -30,11 +31,12 @@ enum InvalidType {
 
 class ParsingResult {
 public:
-	ParsingResult(int cmd = 0, int start = 0, int end = 0, const std::string& d = "", const std::string& name = "", InvalidType type = NO_ERROR)
-		: command(cmd), startlba(start), endlba_or_size(end), data(d), script_name(name), invalidtype(type) {}  
-	ParsingResult(const ParsingResult& other) = default;
-	~ParsingResult() = default;
-
+    ParsingResult(int cmd = 0, int start = 0, int end = 0,
+        const std::string& d = "", const std::string& name = "", InvalidType type = NO_ERROR)
+        : command(cmd), startlba(start), endlba_or_size(end),
+        data(d), script_name(name), invalidtype(type) {}
+    ParsingResult(const ParsingResult& other) = default;
+    ~ParsingResult() = default;
 
     int GetCommand() const { return command; }
     int GetStartLba() const { return startlba; }
@@ -46,13 +48,13 @@ public:
 
     void SetCommand(int cmd) { command = cmd; }
     void SetStartLba(int addr) { startlba = addr; }
-	void SetEndLbaOrSize(int size) { endlba_or_size = size; }
+    void SetEndLbaOrSize(int size) { endlba_or_size = size; }
     void SetData(const std::string& d) { data = d; }
     void SetScriptName(const std::string& name) { script_name = name; }
     void SetInvalidType(InvalidType type) { invalidtype = type; }
 
     bool IsInvalidCommand() const { return invalidtype != NO_ERROR; }
-    bool IsInvalidAddressRange(int lba);
+    bool IsInvalidAddressRange(int lba) { return (lba < 0 || lba >= 100); }
 
 private:
     int command;
@@ -77,7 +79,15 @@ private:
     std::vector<std::string> ParsingInputCommand(std::string command);
     void UpdateInvalidType_and_PrintErrorMessage(int error_type);
     bool UpdateCommand(std::string cmd);
-    bool IsInvalidAddressRange(int lba);
+    bool IsValidAddressRange(int lba);
+    bool Fail(InvalidType type);
+
+    bool HandleWriteCommand(const std::vector<std::string>& tokens);
+    bool HandleReadCommand(const std::vector<std::string>& tokens);
+    bool HandleFullWriteCommand(const std::vector<std::string>& tokens);
+    bool HandleSimpleCommand(const std::vector<std::string>& tokens);
+    bool HandleScriptCommand(const std::vector<std::string>& tokens);
+    bool HandleEraseCommand(const std::vector<std::string>& tokens);
 
     ParsingResult parsingResult;
 };


### PR DESCRIPTION
1. 변경점
- Fail() 함수 선언 추가
- 명령어별 핸들러 함수들 (HandleWriteCommand, HandleReadCommand 등) 선언 추가
- ParsingResult 클래스 내부 필드 및 초기화 시그니처와 Set/Get 메서드 일치

2.검증
[X] Build
[X] Regression Test Pass
[ ] 해당 기능 TC